### PR TITLE
Refactor core package; add KeytoolCommandFactory to encapsulate keytool command options.

### DIFF
--- a/src/main/kotlin/edu/adarko22/jdkcerts/Main.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/Main.kt
@@ -1,12 +1,12 @@
 package edu.adarko22.jdkcerts
 
 import edu.adarko22.jdkcerts.cli.CliBuilder
-import edu.adarko22.jdkcerts.core.jdk.parser.DefaultCertificateInfoParser
-import edu.adarko22.jdkcerts.core.jdk.parser.DefaultJavaInfoParser
-import edu.adarko22.jdkcerts.core.jdk.usecase.DiscoverJdksUseCase
-import edu.adarko22.jdkcerts.core.jdk.usecase.ExecuteFindCertificateKeytoolCommandUseCase
-import edu.adarko22.jdkcerts.core.jdk.usecase.ExecuteKeytoolCommandUseCase
-import edu.adarko22.jdkcerts.core.jdk.usecase.ResolveJavaInfoUseCase
+import edu.adarko22.jdkcerts.core.jdk.DiscoverJdksUseCase
+import edu.adarko22.jdkcerts.core.jdk.java.parser.DefaultJavaInfoParser
+import edu.adarko22.jdkcerts.core.jdk.java.usecase.ResolveJavaInfoUseCase
+import edu.adarko22.jdkcerts.core.jdk.keytool.parser.DefaultCertificateInfoParser
+import edu.adarko22.jdkcerts.core.jdk.keytool.usecase.ExecuteKeytoolCommandUseCase
+import edu.adarko22.jdkcerts.core.jdk.keytool.usecase.FindKeytoolCertificateUseCase
 import edu.adarko22.jdkcerts.infra.execution.DefaultProcessRunner
 import edu.adarko22.jdkcerts.infra.system.SystemType
 
@@ -46,8 +46,8 @@ fun main(args: Array<String>) {
             discoverJdks,
             processRunner,
         )
-    val executeFindCertificateKeytoolCommandUseCase =
-        ExecuteFindCertificateKeytoolCommandUseCase(
+    val findKeytoolCertificateUseCase =
+        FindKeytoolCertificateUseCase(
             executeKeytoolCommandUseCase,
             certificateInfoParser,
         )
@@ -56,7 +56,7 @@ fun main(args: Array<String>) {
     CliBuilder(
         discoverJdks,
         executeKeytoolCommandUseCase,
-        executeFindCertificateKeytoolCommandUseCase,
+        findKeytoolCertificateUseCase,
     ).withInfo()
         .withListJdks()
         .withInstallCert()

--- a/src/main/kotlin/edu/adarko22/jdkcerts/cli/CliBuilder.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/cli/CliBuilder.kt
@@ -12,9 +12,9 @@ import edu.adarko22.jdkcerts.cli.command.jdk.ListJDKsCliCommand
 import edu.adarko22.jdkcerts.cli.command.jdk.RemoveCertCliCommand
 import edu.adarko22.jdkcerts.cli.output.DefaultToolOutputPrinter
 import edu.adarko22.jdkcerts.cli.output.ToolOutputPrinter
-import edu.adarko22.jdkcerts.core.jdk.usecase.DiscoverJdksUseCase
-import edu.adarko22.jdkcerts.core.jdk.usecase.ExecuteFindCertificateKeytoolCommandUseCase
-import edu.adarko22.jdkcerts.core.jdk.usecase.ExecuteKeytoolCommandUseCase
+import edu.adarko22.jdkcerts.core.jdk.DiscoverJdksUseCase
+import edu.adarko22.jdkcerts.core.jdk.keytool.usecase.ExecuteKeytoolCommandUseCase
+import edu.adarko22.jdkcerts.core.jdk.keytool.usecase.FindKeytoolCertificateUseCase
 
 /**
  * Builder for assembling the JDKCertsTool CLI application.
@@ -29,7 +29,7 @@ import edu.adarko22.jdkcerts.core.jdk.usecase.ExecuteKeytoolCommandUseCase
 class CliBuilder(
     private val discoverJdks: DiscoverJdksUseCase,
     private val executeKeytoolCommandUseCase: ExecuteKeytoolCommandUseCase,
-    private val executeFindCertificateKeytoolCommandUseCase: ExecuteFindCertificateKeytoolCommandUseCase,
+    private val findKeytoolCertificateUseCase: FindKeytoolCertificateUseCase,
     private val toolOutputPrinter: ToolOutputPrinter = DefaultToolOutputPrinter(),
 ) : CliEntryPoint {
     // Internal list to hold the selected subcommands
@@ -97,7 +97,7 @@ class CliBuilder(
         apply {
             subcommands.add(
                 FindCertCliCommand(
-                    executeFindCertificateKeytoolCommandUseCase,
+                    findKeytoolCertificateUseCase,
                     findCertCliPresenter,
                 ),
             )

--- a/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/ExecuteKeytoolCommandCliPresenter.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/ExecuteKeytoolCommandCliPresenter.kt
@@ -5,7 +5,7 @@ import edu.adarko22.jdkcerts.cli.output.blue
 import edu.adarko22.jdkcerts.cli.output.green
 import edu.adarko22.jdkcerts.cli.output.red
 import edu.adarko22.jdkcerts.cli.output.yellow
-import edu.adarko22.jdkcerts.core.jdk.KeytoolCommandResult
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolCommandResult
 
 /**
  * CLI presenter responsible for formatting the results for the console output.

--- a/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/FindCertCliCommand.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/FindCertCliCommand.kt
@@ -6,15 +6,15 @@ import edu.adarko22.jdkcerts.cli.command.aliasOption
 import edu.adarko22.jdkcerts.cli.command.customJdkDirsOption
 import edu.adarko22.jdkcerts.cli.command.keystorePasswordOption
 import edu.adarko22.jdkcerts.cli.command.verboseOption
-import edu.adarko22.jdkcerts.core.jdk.KeytoolCommand
-import edu.adarko22.jdkcerts.core.jdk.usecase.ExecuteFindCertificateKeytoolCommandUseCase
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolCommandFactory
+import edu.adarko22.jdkcerts.core.jdk.keytool.usecase.FindKeytoolCertificateUseCase
 import java.nio.file.Path
 
 /**
  * Command for finding a certificate, by its alias, from JDK cacerts keystore across all the JDK installations discovered.
  */
 class FindCertCliCommand(
-    val executeFindCertificateKeytoolCommandUseCase: ExecuteFindCertificateKeytoolCommandUseCase,
+    val findKeytoolCertificateUseCase: FindKeytoolCertificateUseCase,
     private val findCertCliPresenter: FindCertCliPresenter,
 ) : CliktCommand(name = "find-cert") {
     private val customJdkDirs: List<Path> by customJdkDirsOption()
@@ -26,19 +26,8 @@ class FindCertCliCommand(
     override fun help(context: Context) = "Find certificate across all JDK keystores"
 
     override fun run() {
-        val command =
-            KeytoolCommand
-                .Builder()
-                .addArg("-list")
-                .addArg("-v")
-                .addArg("-alias")
-                .addArg(alias)
-                .addArg("-storepass")
-                .addArg(keystorePassword)
-                .withKeystoreResolution()
-                .build()
-
-        val results = executeFindCertificateKeytoolCommandUseCase.execute(keytoolCommand = command, customJdkDirs)
+        val command = KeytoolCommandFactory.findCertificateKeytoolCommand(alias, keystorePassword)
+        val results = findKeytoolCertificateUseCase.execute(keytoolCommand = command, customJdkDirs)
         findCertCliPresenter.present(results, verbose, alias)
     }
 }

--- a/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/FindCertCliPresenter.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/FindCertCliPresenter.kt
@@ -5,8 +5,8 @@ import edu.adarko22.jdkcerts.cli.output.blue
 import edu.adarko22.jdkcerts.cli.output.green
 import edu.adarko22.jdkcerts.cli.output.red
 import edu.adarko22.jdkcerts.cli.output.yellow
-import edu.adarko22.jdkcerts.core.jdk.CertificateInfo
-import edu.adarko22.jdkcerts.core.jdk.KeytoolFindCertResult
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.CertificateInfo
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolFindCertResult
 import java.time.format.DateTimeFormatter
 
 class FindCertCliPresenter(

--- a/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/InstallCertCliCommand.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/InstallCertCliCommand.kt
@@ -7,8 +7,8 @@ import edu.adarko22.jdkcerts.cli.command.certPathOption
 import edu.adarko22.jdkcerts.cli.command.customJdkDirsOption
 import edu.adarko22.jdkcerts.cli.command.dryRunOption
 import edu.adarko22.jdkcerts.cli.command.keystorePasswordOption
-import edu.adarko22.jdkcerts.core.jdk.KeytoolCommand
-import edu.adarko22.jdkcerts.core.jdk.usecase.ExecuteKeytoolCommandUseCase
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolCommandFactory
+import edu.adarko22.jdkcerts.core.jdk.keytool.usecase.ExecuteKeytoolCommandUseCase
 import java.nio.file.Path
 
 /**
@@ -27,21 +27,7 @@ class InstallCertCliCommand(
     override fun help(context: Context) = "Install certificate across all JDK keystores"
 
     override fun run() {
-        val command =
-            KeytoolCommand
-                .Builder()
-                .addArg("-importcert")
-                .addArg("-noprompt")
-                .addArg("-trustcacerts")
-                .addArg("-alias")
-                .addArg(alias)
-                .addArg("-file")
-                .addArg("$certPath")
-                .addArg("-storepass")
-                .addArg(keystorePassword)
-                .withKeystoreResolution()
-                .build()
-
+        val command = KeytoolCommandFactory.installCertificateKeytoolCommand(alias, keystorePassword, certPath.toAbsolutePath().toString())
         val results = executeKeytoolCommandUseCase.execute(keytoolCommand = command, customJdkDirs, dryRun)
         executeKeytoolCommandCliPresenter.present(results, dryRun)
     }

--- a/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/ListJDKsCliCommand.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/ListJDKsCliCommand.kt
@@ -6,7 +6,7 @@ import edu.adarko22.jdkcerts.cli.command.customJdkDirsOption
 import edu.adarko22.jdkcerts.cli.output.ToolOutputPrinter
 import edu.adarko22.jdkcerts.cli.output.green
 import edu.adarko22.jdkcerts.cli.output.red
-import edu.adarko22.jdkcerts.core.jdk.usecase.DiscoverJdksUseCase
+import edu.adarko22.jdkcerts.core.jdk.DiscoverJdksUseCase
 import java.nio.file.Path
 
 /**

--- a/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/RemoveCertCliCommand.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/cli/command/jdk/RemoveCertCliCommand.kt
@@ -6,8 +6,8 @@ import edu.adarko22.jdkcerts.cli.command.aliasOption
 import edu.adarko22.jdkcerts.cli.command.customJdkDirsOption
 import edu.adarko22.jdkcerts.cli.command.dryRunOption
 import edu.adarko22.jdkcerts.cli.command.keystorePasswordOption
-import edu.adarko22.jdkcerts.core.jdk.KeytoolCommand
-import edu.adarko22.jdkcerts.core.jdk.usecase.ExecuteKeytoolCommandUseCase
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolCommandFactory
+import edu.adarko22.jdkcerts.core.jdk.keytool.usecase.ExecuteKeytoolCommandUseCase
 import java.nio.file.Path
 
 /**
@@ -25,17 +25,7 @@ class RemoveCertCliCommand(
     override fun help(context: Context) = "Remove certificate from all JDK keystores"
 
     override fun run() {
-        val command =
-            KeytoolCommand
-                .Builder()
-                .addArg("-delete")
-                .addArg("-alias")
-                .addArg(alias)
-                .addArg("-storepass")
-                .addArg(keystorePassword)
-                .withKeystoreResolution()
-                .build()
-
+        val command = KeytoolCommandFactory.removeCertificateKeytoolCommand(alias, keystorePassword)
         val results = executeKeytoolCommandUseCase.execute(keytoolCommand = command, customJdkDirs, dryRun)
         executeKeytoolCommandCliPresenter.present(results, dryRun)
     }

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/DiscoverJdksUseCase.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/DiscoverJdksUseCase.kt
@@ -1,6 +1,6 @@
-package edu.adarko22.jdkcerts.core.jdk.usecase
+package edu.adarko22.jdkcerts.core.jdk
 
-import edu.adarko22.jdkcerts.core.jdk.Jdk
+import edu.adarko22.jdkcerts.core.jdk.java.usecase.ResolveJavaInfoUseCase
 import edu.adarko22.jdkcerts.infra.system.JdkPathsDiscovery
 import edu.adarko22.jdkcerts.infra.system.KeystoreInfoResolver
 import java.nio.file.Path

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/Jdk.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/Jdk.kt
@@ -1,5 +1,7 @@
 package edu.adarko22.jdkcerts.core.jdk
 
+import edu.adarko22.jdkcerts.core.jdk.java.model.JavaInfo
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeystoreInfo
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/java/model/JavaInfo.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/java/model/JavaInfo.kt
@@ -1,4 +1,4 @@
-package edu.adarko22.jdkcerts.core.jdk
+package edu.adarko22.jdkcerts.core.jdk.java.model
 
 /**
  * Represents Java version information for a specific JDK.

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/java/parser/DefaultJavaInfoParser.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/java/parser/DefaultJavaInfoParser.kt
@@ -1,6 +1,6 @@
-package edu.adarko22.jdkcerts.core.jdk.parser
+package edu.adarko22.jdkcerts.core.jdk.java.parser
 
-import edu.adarko22.jdkcerts.core.jdk.JavaInfo
+import edu.adarko22.jdkcerts.core.jdk.java.model.JavaInfo
 
 /**
  * Default implementation of [JavaInfoParser] that parses typical Java version output.

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/java/parser/JavaInfoParser.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/java/parser/JavaInfoParser.kt
@@ -1,6 +1,6 @@
-package edu.adarko22.jdkcerts.core.jdk.parser
+package edu.adarko22.jdkcerts.core.jdk.java.parser
 
-import edu.adarko22.jdkcerts.core.jdk.JavaInfo
+import edu.adarko22.jdkcerts.core.jdk.java.model.JavaInfo
 
 /**
  * Parses Java version output and extracts structured [JavaInfo].

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/java/usecase/ResolveJavaInfoUseCase.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/java/usecase/ResolveJavaInfoUseCase.kt
@@ -1,8 +1,8 @@
-package edu.adarko22.jdkcerts.core.jdk.usecase
+package edu.adarko22.jdkcerts.core.jdk.java.usecase
 
 import edu.adarko22.jdkcerts.core.execution.ProcessRunner
-import edu.adarko22.jdkcerts.core.jdk.JavaInfo
-import edu.adarko22.jdkcerts.core.jdk.parser.JavaInfoParser
+import edu.adarko22.jdkcerts.core.jdk.java.model.JavaInfo
+import edu.adarko22.jdkcerts.core.jdk.java.parser.JavaInfoParser
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/CertificateInfo.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/CertificateInfo.kt
@@ -1,4 +1,4 @@
-package edu.adarko22.jdkcerts.core.jdk
+package edu.adarko22.jdkcerts.core.jdk.keytool.model
 
 import java.time.LocalDateTime
 

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeystoreInfo.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeystoreInfo.kt
@@ -1,4 +1,4 @@
-package edu.adarko22.jdkcerts.core.jdk
+package edu.adarko22.jdkcerts.core.jdk.keytool.model
 
 import java.nio.file.Path
 

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeytoolCommand.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeytoolCommand.kt
@@ -1,4 +1,4 @@
-package edu.adarko22.jdkcerts.core.jdk
+package edu.adarko22.jdkcerts.core.jdk.keytool.model
 
 /**
  * Represents a `keytool` command with arguments and optional keystore resolution.

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeytoolCommandFactory.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeytoolCommandFactory.kt
@@ -1,0 +1,53 @@
+package edu.adarko22.jdkcerts.core.jdk.keytool.model
+
+class KeytoolCommandFactory {
+    companion object {
+        fun findCertificateKeytoolCommand(
+            alias: String,
+            keystorePassword: String,
+        ): KeytoolCommand =
+            KeytoolCommand
+                .Builder()
+                .addArg("-list")
+                .addArg("-v")
+                .addArg("-alias")
+                .addArg(alias)
+                .addArg("-storepass")
+                .addArg(keystorePassword)
+                .withKeystoreResolution()
+                .build()
+
+        fun installCertificateKeytoolCommand(
+            alias: String,
+            keystorePassword: String,
+            certificateAbsolutePath: String,
+        ): KeytoolCommand =
+            KeytoolCommand
+                .Builder()
+                .addArg("-importcert")
+                .addArg("-noprompt")
+                .addArg("-trustcacerts")
+                .addArg("-alias")
+                .addArg(alias)
+                .addArg("-file")
+                .addArg(certificateAbsolutePath)
+                .addArg("-storepass")
+                .addArg(keystorePassword)
+                .withKeystoreResolution()
+                .build()
+
+        fun removeCertificateKeytoolCommand(
+            alias: String,
+            keystorePassword: String,
+        ): KeytoolCommand =
+            KeytoolCommand
+                .Builder()
+                .addArg("-delete")
+                .addArg("-alias")
+                .addArg(alias)
+                .addArg("-storepass")
+                .addArg(keystorePassword)
+                .withKeystoreResolution()
+                .build()
+    }
+}

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeytoolCommandResult.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeytoolCommandResult.kt
@@ -1,6 +1,7 @@
-package edu.adarko22.jdkcerts.core.jdk
+package edu.adarko22.jdkcerts.core.jdk.keytool.model
 
 import edu.adarko22.jdkcerts.core.execution.ProcessResult
+import edu.adarko22.jdkcerts.core.jdk.Jdk
 
 /**
  * Represents the outcome of a keytool process execution on a specific JDK.

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeytoolFindCertResult.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/model/KeytoolFindCertResult.kt
@@ -1,4 +1,6 @@
-package edu.adarko22.jdkcerts.core.jdk
+package edu.adarko22.jdkcerts.core.jdk.keytool.model
+
+import edu.adarko22.jdkcerts.core.jdk.Jdk
 
 /**
  * Represents the high-level result of searching for a specific certificate in a JDK.

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/parser/CertificateInfoParser.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/parser/CertificateInfoParser.kt
@@ -1,6 +1,6 @@
-package edu.adarko22.jdkcerts.core.jdk.parser
+package edu.adarko22.jdkcerts.core.jdk.keytool.parser
 
-import edu.adarko22.jdkcerts.core.jdk.CertificateInfo
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.CertificateInfo
 
 /**
  * Contract for parsing raw keytool output into a structured [CertificateInfo] object.

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/parser/DefaultCertificateInfoParser.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/parser/DefaultCertificateInfoParser.kt
@@ -1,6 +1,6 @@
-package edu.adarko22.jdkcerts.core.jdk.parser
+package edu.adarko22.jdkcerts.core.jdk.keytool.parser
 
-import edu.adarko22.jdkcerts.core.jdk.CertificateInfo
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.CertificateInfo
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/usecase/ExecuteKeytoolCommandUseCase.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/usecase/ExecuteKeytoolCommandUseCase.kt
@@ -1,9 +1,10 @@
-package edu.adarko22.jdkcerts.core.jdk.usecase
+package edu.adarko22.jdkcerts.core.jdk.keytool.usecase
 
 import edu.adarko22.jdkcerts.core.execution.ProcessRunner
+import edu.adarko22.jdkcerts.core.jdk.DiscoverJdksUseCase
 import edu.adarko22.jdkcerts.core.jdk.Jdk
-import edu.adarko22.jdkcerts.core.jdk.KeytoolCommand
-import edu.adarko22.jdkcerts.core.jdk.KeytoolCommandResult
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolCommand
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolCommandResult
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 

--- a/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/usecase/FindKeytoolCertificateUseCase.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/core/jdk/keytool/usecase/FindKeytoolCertificateUseCase.kt
@@ -1,9 +1,9 @@
-package edu.adarko22.jdkcerts.core.jdk.usecase
+package edu.adarko22.jdkcerts.core.jdk.keytool.usecase
 
-import edu.adarko22.jdkcerts.core.jdk.KeytoolCommand
-import edu.adarko22.jdkcerts.core.jdk.KeytoolCommandResult
-import edu.adarko22.jdkcerts.core.jdk.KeytoolFindCertResult
-import edu.adarko22.jdkcerts.core.jdk.parser.CertificateInfoParser
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolCommand
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolCommandResult
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeytoolFindCertResult
+import edu.adarko22.jdkcerts.core.jdk.keytool.parser.CertificateInfoParser
 import java.nio.file.Path
 
 /**
@@ -15,7 +15,7 @@ import java.nio.file.Path
  * @param executeKeytoolCommandUseCase The underlying use case for running keytool commands.
  * @param certificateInfoParser Component responsible for parsing raw keytool output into [KeytoolFindCertResult].
  */
-class ExecuteFindCertificateKeytoolCommandUseCase(
+class FindKeytoolCertificateUseCase(
     val executeKeytoolCommandUseCase: ExecuteKeytoolCommandUseCase,
     val certificateInfoParser: CertificateInfoParser,
 ) {

--- a/src/main/kotlin/edu/adarko22/jdkcerts/infra/system/KeystoreInfoResolver.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/infra/system/KeystoreInfoResolver.kt
@@ -1,7 +1,7 @@
 package edu.adarko22.jdkcerts.infra.system
 
-import edu.adarko22.jdkcerts.core.jdk.JavaInfo
-import edu.adarko22.jdkcerts.core.jdk.KeystoreInfo
+import edu.adarko22.jdkcerts.core.jdk.java.model.JavaInfo
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeystoreInfo
 import java.nio.file.Path
 
 /**

--- a/src/main/kotlin/edu/adarko22/jdkcerts/infra/system/unix/UNIXKeystoreInfoResolver.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/infra/system/unix/UNIXKeystoreInfoResolver.kt
@@ -1,7 +1,7 @@
 package edu.adarko22.jdkcerts.infra.system.unix
 
-import edu.adarko22.jdkcerts.core.jdk.JavaInfo
-import edu.adarko22.jdkcerts.core.jdk.KeystoreInfo
+import edu.adarko22.jdkcerts.core.jdk.java.model.JavaInfo
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.KeystoreInfo
 import edu.adarko22.jdkcerts.infra.system.KeystoreInfoResolver
 import java.nio.file.Files
 import java.nio.file.Path

--- a/src/test/kotlin/edu/adarko22/jdkcerts/core/jdk/parser/DefaultCertificateInfoParserTest.kt
+++ b/src/test/kotlin/edu/adarko22/jdkcerts/core/jdk/parser/DefaultCertificateInfoParserTest.kt
@@ -1,6 +1,7 @@
 package edu.adarko22.jdkcerts.core.jdk.parser
 
-import edu.adarko22.jdkcerts.core.jdk.CertificateInfo
+import edu.adarko22.jdkcerts.core.jdk.keytool.model.CertificateInfo
+import edu.adarko22.jdkcerts.core.jdk.keytool.parser.DefaultCertificateInfoParser
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.params.ParameterizedTest

--- a/src/test/kotlin/edu/adarko22/jdkcerts/core/jdk/parser/DefaultJavaInfoParserTest.kt
+++ b/src/test/kotlin/edu/adarko22/jdkcerts/core/jdk/parser/DefaultJavaInfoParserTest.kt
@@ -1,6 +1,7 @@
 package edu.adarko22.jdkcerts.core.jdk.parser
 
-import edu.adarko22.jdkcerts.core.jdk.JavaInfo
+import edu.adarko22.jdkcerts.core.jdk.java.model.JavaInfo
+import edu.adarko22.jdkcerts.core.jdk.java.parser.DefaultJavaInfoParser
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.params.ParameterizedTest

--- a/src/test/kotlin/edu/adarko22/jdkcerts/infra/system/unix/UNIXKeystoreInfoResolverTest.kt
+++ b/src/test/kotlin/edu/adarko22/jdkcerts/infra/system/unix/UNIXKeystoreInfoResolverTest.kt
@@ -1,6 +1,6 @@
 package edu.adarko22.jdkcerts.infra.system.unix
 
-import edu.adarko22.jdkcerts.core.jdk.JavaInfo
+import edu.adarko22.jdkcerts.core.jdk.java.model.JavaInfo
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir


### PR DESCRIPTION
This PR refactors the core package structure of the `JDKCertsTool` project by introducing a hierarchical directory organization that separates Java-related and Keytool-related functionality, and creates a `KeytoolCommandFactory` class to encapsulate and simplify keytool command construction. 

The refactoring eliminates repetitive command-building logic from CLI commands while improving code organization.