### PR TITLE
Override default JDK discovery when custom paths are provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ certificates—especially across multiple installed JDKs—can be a pain.
 
 - ✅ **Add or remove custom certificates** (like corporate or internal CA certs).
 - 🔍 **Search Certificates** by _exact-match, fuzzy-match or regex_ on alias.
-- 🔍 **Discover installed JDKs**.
+- 🔍 **Discover installed JDKs** automatically, or limit scopes to explicitly isolated paths.
 - 🔐 Uses [keytool](https://docs.oracle.com/javase/10/tools/keytool.htm) under the hood — no need to learn its syntax.
 - ⚡ Executes keytool operations in parallel across discovered JDKs for better throughput.
 
@@ -82,6 +82,11 @@ actual values, and to remove `--dry-run` for permanent changes.
 
 ## 💡 Commands Overview
 
+> ⚠️ **Default Scanning vs Custom Override Mode:**
+>
+> Using the `--custom-jdk-dirs` option disables automatic system scanning.
+> The tool will run strictly on the paths you provide, keeping your execution isolated and safe.
+
 ### 🔍 info
 
 Displays basic project and environment info.
@@ -108,10 +113,10 @@ jdkcerts list-jdks [--custom-jdk-dirs <VALUE>]
 
 **Options:**
 
-| Option                    | Description                                         |
-|---------------------------|-----------------------------------------------------|
-| --custom-jdk-dirs <VALUE> | Comma-separated paths to JDK directories (optional) |
-| -h, --help                | Show this message and exit                          |
+| Option                    | Description                                                                     |
+|---------------------------|---------------------------------------------------------------------------------|
+| --custom-jdk-dirs <VALUE> | Comma-separated paths to JDK directories (optional). Bypasses default scanning. |
+| -h, --help                | Show this message and exit                                                      |
 
 ---
 
@@ -125,14 +130,14 @@ jdkcerts install-cert --cert <PATH> --alias <ALIAS> [--keystore-password <PASSWO
 
 **Options:**
 
-| Option                     | Description                                         | Default    |
-|----------------------------|-----------------------------------------------------|------------|
-| --cert <VALUE>             | Path to the certificate file (**required**)         |            |
-| --alias <TEXT>             | Certificate alias (**required**)                    |            |
-| --keystore-password <TEXT> | Keystore password                                   | `changeit` |
-| --custom-jdk-dirs <VALUE>  | Comma-separated paths to JDK directories (optional) |            |
-| --dry-run                  | Preview changes without modifying anything          |            |
-| -h, --help                 | Show this message and exit                          |            |
+| Option                     | Description                                                                     | Default    |
+|----------------------------|---------------------------------------------------------------------------------|------------|
+| --cert <VALUE>             | Path to the certificate file (**required**)                                     |            |
+| --alias <TEXT>             | Certificate alias (**required**)                                                |            |
+| --keystore-password <TEXT> | Keystore password                                                               | `changeit` |
+| --custom-jdk-dirs <VALUE>  | Comma-separated paths to JDK directories (optional). Bypasses default scanning. |            |
+| --dry-run                  | Preview changes without modifying anything                                      |            |
+| -h, --help                 | Show this message and exit                                                      |            |
 
 **Example:**
 
@@ -156,13 +161,13 @@ jdkcerts remove-cert --alias <ALIAS> [--keystore-password <PASSWORD>] [--dry-run
 
 **Options:**
 
-| Option                     | Description                                         | Default    |
-|----------------------------|-----------------------------------------------------|------------|
-| --alias <TEXT>             | Certificate alias (**required**)                    |            |
-| --keystore-password <TEXT> | Keystore password                                   | `changeit` |
-| --custom-jdk-dirs <VALUE>  | Comma-separated paths to JDK directories (optional) |            |
-| --dry-run                  | Preview changes without modifying anything          |            |
-| -h, --help                 | Show this message and exit                          |            |
+| Option                     | Description                                                                     | Default    |
+|----------------------------|---------------------------------------------------------------------------------|------------|
+| --alias <TEXT>             | Certificate alias (**required**)                                                |            |
+| --keystore-password <TEXT> | Keystore password                                                               | `changeit` |
+| --custom-jdk-dirs <VALUE>  | Comma-separated paths to JDK directories (optional). Bypasses default scanning. |            |
+| --dry-run                  | Preview changes without modifying anything                                      |            |
+| -h, --help                 | Show this message and exit                                                      |            |
 
 **Example:**
 
@@ -192,15 +197,15 @@ jdkcerts find-cert --alias <ALIAS> [--keystore-password <PASSWORD>] [--verbose] 
 
 **Options:**
 
-| Option                     | Description                                                  | Default    |
-|----------------------------|--------------------------------------------------------------|------------|
-| --alias <TEXT>             | Certificate alias or search pattern (**required**)           |            |
-| --keystore-password <TEXT> | Keystore password                                            | `changeit` |
-| --verbose                  | Display all certificate details (SHA1, SHA256, Serial, etc.) | `false`    |
-| --regex                    | Search by regex pattern instead of exact match               |            |
-| --closest-match            | Search by closest match (fuzzy matching for typos)           |            |
-| --custom-jdk-dirs <VALUE>  | Comma-separated paths to JDK directories (optional)          |            |
-| -h, --help                 | Show this message and exit                                   |            |
+| Option                     | Description                                                                     | Default    |
+|----------------------------|---------------------------------------------------------------------------------|------------|
+| --alias <TEXT>             | Certificate alias or search pattern (**required**)                              |            |
+| --keystore-password <TEXT> | Keystore password                                                               | `changeit` |
+| --verbose                  | Display all certificate details (SHA1, SHA256, Serial, etc.)                    | `false`    |
+| --regex                    | Search by regex pattern instead of exact match                                  |            |
+| --closest-match            | Search by closest match (fuzzy matching for typos)                              |            |
+| --custom-jdk-dirs <VALUE>  | Comma-separated paths to JDK directories (optional). Bypasses default scanning. |            |
+| -h, --help                 | Show this message and exit                                                      |            |
 
 **Examples:**
 

--- a/src/main/kotlin/edu/adarko22/jdkcerts/infra/system/JdkPathsDiscovery.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/infra/system/JdkPathsDiscovery.kt
@@ -3,14 +3,18 @@ package edu.adarko22.jdkcerts.infra.system
 import java.nio.file.Path
 
 /**
- * Discovers JDK installation paths on the host system.
+ * Strategy boundary for identifying JDK installation paths on the host system.
  */
 interface JdkPathsDiscovery {
     /**
-     * Provides JDK installation paths on the host system.
+     * Resolves and validates absolute home paths of available JDK installations.
      *
-     * @param customJdkDirs Optional list of additional directories to search.
-     * @return List of discovered JDK home paths.
+     * ### Discovery Modes:
+     * - **Automatic Mode (Empty List):** The scanner falls back to standard platform locations .
+     * - **Exclusive Mode (Non-Empty List):** Scan only the paths provided in [customJdkDirs].
+     *
+     * @param customJdkDirs Explicit root directories provided by the runtime context to restrict searching.
+     * @return A distinct, filtered list of validated Java home paths containing runnable binaries.
      */
-    fun discover(customJdkDirs: List<Path> = emptyList()): List<Path>
+    fun discover(customJdkDirs: List<Path>): List<Path>
 }

--- a/src/main/kotlin/edu/adarko22/jdkcerts/infra/system/unix/UNIXJdkPathsDiscovery.kt
+++ b/src/main/kotlin/edu/adarko22/jdkcerts/infra/system/unix/UNIXJdkPathsDiscovery.kt
@@ -23,10 +23,14 @@ class UNIXJdkPathsDiscovery(
             systemInfoProvider.getUserHome().resolve(".sdkman/candidates/java").takeIf(Files::isDirectory),
         )
 
+    /**
+     * Validates candidate roots by confirming the active existence of structural execution subfiles
+     * via [isValidJavaHome] before calculating real paths to eliminate symlink duplicates.
+     */
     override fun discover(customJdkDirs: List<Path>): List<Path> {
-        val allSearchRoots = defaultDirs + discoverJetBrainsRuntimeHomes() + customJdkDirs.filter(Files::isDirectory)
-
-        return allSearchRoots
+        val searchDirs = customJdkDirs.ifEmpty { defaultDirs + discoverJetBrainsRuntimeHomes() }
+        return searchDirs
+            .filter(Files::isDirectory)
             .asSequence()
             .flatMap { Files.newDirectoryStream(it) }
             .map { toJavaHome(it) }
@@ -36,7 +40,10 @@ class UNIXJdkPathsDiscovery(
             .toList()
     }
 
-    // Now uses the class's userHome property
+    /**
+     * Inspects active user context home regions to isolate runtimes packaged inside
+     * desktop IntelliJ IDEA applications and JetBrains Toolbox installation hubs.
+     */
     internal fun discoverJetBrainsRuntimeHomes(): List<Path> {
         val jdkPaths = mutableListOf<Path>()
 


### PR DESCRIPTION
Providing `--custom-jdk-dirs` now completely bypasses default system scanning instead of appending to it, ensuring safe execution isolation.